### PR TITLE
The text diff correction from a validated writing practice card was p…

### DIFF
--- a/app.js
+++ b/app.js
@@ -1176,6 +1176,7 @@ document.addEventListener('DOMContentLoaded', () => {
             nextCardButton.classList.remove('hidden');
         }
         comparisonContainer.classList.add('hidden');
+        comparisonContainer.innerHTML = ''; // Clear previous diff content
 
         await saveCardStats(cardKey, stats);
         cardShownTimestamp = Date.now();


### PR DESCRIPTION
…ersisting and being displayed on the next card.

This was because the `comparisonContainer` element was not being cleared when a new card was displayed.

The fix is to add a line in the `displayCard` function to clear the `innerHTML` of the `comparisonContainer`, ensuring that no old content can persist between cards.