### PR TITLE
feat: Overhaul flashcard UI and add new features

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,10 @@
                 <textarea id="filter-text" rows="5" placeholder="Paste text here..."></textarea>
                 <small>The deck will only show cards where the 'Target Language' column matches a word from this text.</small>
             </div>
+            <div class="setting">
+                <input type="checkbox" id="filter-allow-overflow">
+                <label for="filter-allow-overflow">Allow other cards after filtered set is learned</label>
+            </div>
             <div class="button-container">
                 <button id="apply-filter-button">Apply Filter</button>
                 <button id="clear-filter-button" class="danger">Clear Filter</button>
@@ -274,6 +278,7 @@
         <input type="text" id="writing-input" placeholder="Type the answer...">
         <button id="writing-submit">Submit</button>
       </div>
+      <div id="explanation-message"></div>
     </div>
 
     <div id="controls">
@@ -284,8 +289,6 @@
       <button id="next-card"><span>➡️</span><span class="btn-text"> Next (&rarr;)</span></button>
       <button id="slow-replay-hotkey"><span>🔁</span><span class="btn-text"> Replay (f)</span></button>
     </div>
-
-    <div id="explanation-message"></div>
     <script src="https://cdn.jsdelivr.net/npm/diff/dist/diff.min.js"></script>
     <script type="module" src="app.js"></script>
   </body>

--- a/style.css
+++ b/style.css
@@ -410,8 +410,8 @@ th.sortable.desc::after {
 }
 
 #explanation-message {
-    position: fixed;
-    top: 70px; /* Moved from bottom */
+    position: absolute; /* Changed from fixed */
+    top: 10px; /* Adjust as needed */
     left: 50%;
     transform: translateX(-50%);
     background: rgba(0,0,0,0.8);
@@ -420,11 +420,12 @@ th.sortable.desc::after {
     border-radius: 10px;
     font-size: 1em;
     opacity: 0;
-    transition: opacity 0.5s, top 0.5s; /* Added top to transition */
-    z-index: 10;
+    transition: opacity 0.5s, top 0.5s;
+    z-index: 20; /* Higher than the card faces */
     text-align: center;
     width: auto;
     max-width: 80%;
+    pointer-events: none; /* So it doesn't interfere with card clicks/drags */
 }
 
 #explanation-message.visible {


### PR DESCRIPTION
This commit introduces a wide range of improvements and new features to the flashcard application based on user feedback.

Major changes include:
- Renamed the 'Subset' feature to 'Filter' and changed its functionality to be a temporary filter on the current deck rather than creating a new configuration.
- Added a 'Delete All Skills' button to the skill management UI.
- Implemented a default 'Reading & Listening' skill that is automatically created for new configurations.
- Refactored the card selection logic to prioritize cards that have been seen in previous skills, encouraging a more structured learning path.
- Moved the 'Alternate Uppercase' and 'Only read on hotkey' settings from the global advanced settings to be per-skill settings.
- Simplified the 'Audio-Only' mode to be implicit: a skill is audio-only if it has no front columns but has a TTS front column.
- Moved the explanation message to the top-center of the card for better visibility.