### PR TITLE
Fix: Prevent speech synthesis crashes by clearing queue

### DIFF
--- a/app.js
+++ b/app.js
@@ -2512,6 +2512,9 @@ function speak(text, { rate, lang, ttsRole } = {}) {
     }
 
     utterance.rate = finalRate;
+
+        // Prevent speech queue conflicts and browser crashes
+        window.speechSynthesis.cancel();
         window.speechSynthesis.speak(utterance);
     }
 


### PR DESCRIPTION
The Web Speech API (`speechSynthesis`) can become unstable and crash on certain platforms (e.g., macOS) if `speechSynthesis.speak()` is called in quick succession without clearing the queue.

This commit fixes the issue by ensuring that `speechSynthesis.cancel()` is called immediately before every call to `speechSynthesis.speak()`.

The change is applied in the centralized `speak()` wrapper function in `app.js` to ensure all speech synthesis calls throughout the application are stabilized. An explanatory comment has also been added as requested.