### PR TITLE
feat(testing): Add tests for word filtering and highlighting

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import { eld } from 'https://cdn.jsdelivr.net/npm/efficient-language-detector-no
 import { get, set, del, keys } from 'https://cdn.jsdelivr.net/npm/idb-keyval/+esm';
 import { getLenientString, transformSlashText } from './lib/string-utils.js';
 import { Skill, createSkillId, createSkill, VERIFICATION_METHODS } from './lib/skill-utils.js';
+import { getDeckWords, getHighlightHTML } from './lib/filter-utils.js';
 
 /**
  * @file Main application logic for the Flashcards web app.
@@ -608,35 +609,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // The actual filtering logic is now tied to showNextCard, which respects the checkbox state.
     }
 
-    function getDeckWords() {
-        const roleToColumnMap = (configs[configSelector.value] || {}).roleToColumnMap || {};
-        const keyIndices = roleToColumnMap['TARGET_LANGUAGE'] || [];
-        if (keyIndices.length !== 1) return new Set();
-
-        const keyIndex = keyIndices[0];
-        const deckWords = new Set();
-        cardData.forEach(card => {
-            const key = card[keyIndex]?.toLowerCase();
-            if (key) {
-                // Split by non-letter characters to handle multiple words in one cell
-                key.match(/[\p{L}\p{N}]+/gu)?.forEach(word => deckWords.add(word));
-            }
-        });
-        return deckWords;
-    }
-
-    function getHighlightHTML(text, intersection) {
-        // Escape HTML to prevent XSS and then highlight
-        const escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const highlightedHtml = escapedText.replace(/[\p{L}\p{N}]+/gu, (word) => {
-            if (intersection.has(word.toLowerCase())) {
-                return `<span class="match">${word}</span>`;
-            }
-            return word;
-        });
-        return highlightedHtml;
-    }
-
     function updateFilterHighlights() {
         if (!filterTextarea || !filterHighlightLayer || !filterIntersectionInfo) return;
 
@@ -647,7 +619,9 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const deckWords = getDeckWords();
+        const currentConfig = configs[configSelector.value] || {};
+        const roleToColumnMap = currentConfig.roleToColumnMap;
+        const deckWords = getDeckWords(cardData, roleToColumnMap);
         if (deckWords.size === 0) {
             filterHighlightLayer.innerHTML = '';
             filterIntersectionInfo.textContent = 'Load a deck to see matching words.';

--- a/lib/filter-utils.js
+++ b/lib/filter-utils.js
@@ -1,3 +1,5 @@
+const WORD_REGEX = /[\p{L}\p{N}]+/gu;
+
 export function getDeckWords(data, roleToColumnMap) {
     if (!roleToColumnMap || !data) {
         return new Set();
@@ -11,7 +13,7 @@ export function getDeckWords(data, roleToColumnMap) {
         const key = card[keyIndex]?.toLowerCase();
         if (key) {
             // Split by non-letter characters to handle multiple words in one cell
-            key.match(/[\p{L}\p{N}]+/gu)?.forEach(word => deckWords.add(word));
+            key.match(WORD_REGEX)?.forEach(word => deckWords.add(word));
         }
     });
     return deckWords;
@@ -19,8 +21,13 @@ export function getDeckWords(data, roleToColumnMap) {
 
 export function getHighlightHTML(text, intersection) {
     // Escape HTML to prevent XSS and then highlight
-    const escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const highlightedHtml = escapedText.replace(/[\p{L}\p{N}]+/gu, (word) => {
+    const escapedText = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    const highlightedHtml = escapedText.replace(WORD_REGEX, (word) => {
         if (intersection.has(word.toLowerCase())) {
             return `<span class="match">${word}</span>`;
         }

--- a/lib/filter-utils.js
+++ b/lib/filter-utils.js
@@ -1,0 +1,30 @@
+export function getDeckWords(data, roleToColumnMap) {
+    if (!roleToColumnMap || !data) {
+        return new Set();
+    }
+    const keyIndices = roleToColumnMap['TARGET_LANGUAGE'] || [];
+    if (keyIndices.length !== 1) return new Set();
+
+    const keyIndex = keyIndices[0];
+    const deckWords = new Set();
+    data.forEach(card => {
+        const key = card[keyIndex]?.toLowerCase();
+        if (key) {
+            // Split by non-letter characters to handle multiple words in one cell
+            key.match(/[\p{L}\p{N}]+/gu)?.forEach(word => deckWords.add(word));
+        }
+    });
+    return deckWords;
+}
+
+export function getHighlightHTML(text, intersection) {
+    // Escape HTML to prevent XSS and then highlight
+    const escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const highlightedHtml = escapedText.replace(/[\p{L}\p{N}]+/gu, (word) => {
+        if (intersection.has(word.toLowerCase())) {
+            return `<span class="match">${word}</span>`;
+        }
+        return word;
+    });
+    return highlightedHtml;
+}

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import { getDeckWords, getHighlightHTML } from '../lib/filter-utils.js';
+
+describe('getDeckWords', () => {
+    const roleToColumnMap = {
+        'TARGET_LANGUAGE': [0],
+        'BASE_LANGUAGE': [1],
+    };
+
+    it('should return a Set of unique words from a standard dataset', () => {
+        const cardData = [
+            ['hello', 'hola'],
+            ['world', 'mundo'],
+            ['hello', 'bonjour'],
+        ];
+        const result = getDeckWords(cardData, roleToColumnMap);
+        expect(result).to.be.an.instanceOf(Set);
+        expect(result).to.deep.equal(new Set(['hello', 'world']));
+    });
+
+    it('should handle cards where the "Target Language" field is empty or missing', () => {
+        const cardData = [
+            ['apple', 'manzana'],
+            [null, 'pera'],
+            ['grape', 'uva'],
+            ['', 'naranja'],
+        ];
+        const result = getDeckWords(cardData, roleToColumnMap);
+        expect(result).to.deep.equal(new Set(['apple', 'grape']));
+    });
+
+    it('should handle an empty array of card data, returning an empty Set', () => {
+        const cardData = [];
+        const result = getDeckWords(cardData, roleToColumnMap);
+        expect(result).to.be.an.instanceOf(Set);
+        expect(result.size).to.equal(0);
+    });
+
+    it('should correctly parse fields containing multiple words', () => {
+        const cardData = [
+            ['ice cream', 'helado'],
+            ['hot dog', 'perro caliente'],
+        ];
+        const result = getDeckWords(cardData, roleToColumnMap);
+        expect(result).to.deep.equal(new Set(['ice', 'cream', 'hot', 'dog']));
+    });
+
+    it('should correctly handle duplicate words across different cards, only including them once', () => {
+        const cardData = [
+            ['red apple', 'manzana roja'],
+            ['red car', 'coche rojo'],
+        ];
+        const result = getDeckWords(cardData, roleToColumnMap);
+        expect(result).to.deep.equal(new Set(['red', 'apple', 'car']));
+    });
+});
+
+describe('getHighlightHTML', () => {
+    it('should wrap a single matching word in <span class="match">', () => {
+        const text = 'hello world';
+        const intersection = new Set(['hello']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('<span class="match">hello</span> world');
+    });
+
+    it('should wrap multiple, non-adjacent matching words', () => {
+        const text = 'the quick brown fox jumps over the lazy dog';
+        const intersection = new Set(['fox', 'dog']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('the quick brown <span class="match">fox</span> jumps over the lazy <span class="match">dog</span>');
+    });
+
+    it('should return the original text unmodified if there are no matching words', () => {
+        const text = 'hello world';
+        const intersection = new Set(['goodbye']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('hello world');
+    });
+
+    it('should handle an empty input string, returning an empty string', () => {
+        const text = '';
+        const intersection = new Set(['hello']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('');
+    });
+
+    it('should handle an empty intersection Set, returning the original text', () => {
+        const text = 'this is a test';
+        const intersection = new Set();
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('this is a test');
+    });
+
+    it('(Security) should correctly escape HTML special characters in the input text', () => {
+        const text = '<script>alert("xss")</script> & some text';
+        const intersection = new Set(['script', 'text']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('&lt;<span class="match">script</span>&gt;alert("xss")&lt;/<span class="match">script</span>&gt; &amp; some <span class="match">text</span>');
+    });
+
+    it('(Case Insensitivity) should match words regardless of their case', () => {
+        const text = 'Apple and apple are the same.';
+        const intersection = new Set(['apple']); // Intersection is lowercase
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('<span class="match">Apple</span> and <span class="match">apple</span> are the same.');
+    });
+});

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -95,7 +95,14 @@ describe('getHighlightHTML', () => {
         const text = '<script>alert("xss")</script> & some text';
         const intersection = new Set(['script', 'text']);
         const result = getHighlightHTML(text, intersection);
-        expect(result).to.equal('&lt;<span class="match">script</span>&gt;alert("xss")&lt;/<span class="match">script</span>&gt; &amp; some <span class="match">text</span>');
+        expect(result).to.equal('&lt;<span class="match">script</span>&gt;alert(&quot;xss&quot;)&lt;/<span class="match">script</span>&gt; &amp; some <span class="match">text</span>');
+    });
+
+    it('(Security) should correctly escape single and double quotes', () => {
+        const text = `it's a "quote"`;
+        const intersection = new Set(['quote']);
+        const result = getHighlightHTML(text, intersection);
+        expect(result).to.equal('it&#039;s a &quot;<span class="match">quote</span>&quot;');
     });
 
     it('(Case Insensitivity) should match words regardless of their case', () => {

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -99,7 +99,7 @@ describe('getHighlightHTML', () => {
     });
 
     it('(Security) should correctly escape single and double quotes', () => {
-        const text = `it's a "quote"`;
+        const text = 'it\'s a "quote"';
         const intersection = new Set(['quote']);
         const result = getHighlightHTML(text, intersection);
         expect(result).to.equal('it&#039;s a &quot;<span class="match">quote</span>&quot;');


### PR DESCRIPTION
Refactors `getDeckWords` and `getHighlightHTML` to be pure functions, improving testability and modularity.

Moves the functions to a new `lib/filter-utils.js` file to decouple them from the browser-specific `app.js`.

Introduces a new test suite in `test/filter.test.js` using Mocha and Chai. The tests cover all acceptance criteria, including standard functionality, edge cases, HTML escaping for security, and case-insensitivity.