### PR TITLE
feat: Update default skills and add drag-and-drop reordering

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,6 +393,26 @@ document.addEventListener('DOMContentLoaded', () => {
                 deleteSkill(skillId);
             }
         });
+
+        Sortable.create(skillsList, {
+            animation: 150,
+            onEnd: function (evt) {
+                const currentConfigName = configSelector.value;
+                const currentConfig = configs[currentConfigName];
+                if (!currentConfig || !currentConfig.skills) return;
+
+                // The evt.oldIndex and evt.newIndex are what we need.
+                // Get the skill that was moved
+                const movedSkill = currentConfig.skills.splice(evt.oldIndex, 1)[0];
+                // Re-insert it at the new index
+                currentConfig.skills.splice(evt.newIndex, 0, movedSkill);
+
+
+                // Mark the configuration as changed and refresh UI that depends on skill order
+                handleSettingsChange();
+                populateSkillSelector();
+            }
+        });
     }
 
     const closeSkillConfigButton = document.getElementById('close-skill-config-button');

--- a/app.js
+++ b/app.js
@@ -404,6 +404,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // The evt.oldIndex and evt.newIndex are what we need.
                 // Get the skill that was moved
                 const movedSkill = currentConfig.skills.splice(evt.oldIndex, 1)[0];
+                if (!movedSkill) return; // Guard against undefined skill
                 // Re-insert it at the new index
                 currentConfig.skills.splice(evt.newIndex, 0, movedSkill);
 

--- a/index.html
+++ b/index.html
@@ -321,6 +321,7 @@
       <button id="slow-replay-hotkey"><span>🔁</span><span class="btn-text"> Replay (f)</span></button>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/diff/dist/diff.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
       <button id="slow-replay-hotkey"><span>🔁</span><span class="btn-text"> Replay (f)</span></button>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/diff/dist/diff.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/lib/default-skills.json
+++ b/lib/default-skills.json
@@ -1,9 +1,57 @@
 [
-  {"name": "Reading & Listening", "front": ["TARGET_LANGUAGE"], "back": ["BASE_LANGUAGE", "PRONUNCIATION", "GRAMMATICAL_TYPE"], "verificationMethod": "none", "ttsFrontColumn": "TARGET_LANGUAGE", "ttsBackColumn": "BASE_LANGUAGE", "alternateUppercase": true, "ttsOnHotkeyOnly": true},
-  {"name": "Reading Comprehension", "front": ["TARGET_LANGUAGE"], "back": ["BASE_LANGUAGE", "PRONUNCIATION"], "verificationMethod": "none", "ttsFrontColumn": "none", "ttsBackColumn": "BASE_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": false},
-  {"name": "Listening Comprehension", "front": [], "back": ["BASE_LANGUAGE", "PRONUNCIATION", "TARGET_LANGUAGE"], "verificationMethod": "none", "ttsFrontColumn": "TARGET_LANGUAGE", "ttsBackColumn": "BASE_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": true},
-  {"name": "Validated Writing Practice", "front": ["BASE_LANGUAGE"], "back": ["TARGET_LANGUAGE"], "verificationMethod": "text", "validationColumn": "TARGET_LANGUAGE", "ttsFrontColumn": "BASE_LANGUAGE", "ttsBackColumn": "TARGET_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": false},
-  {"name": "Spoken Production", "front": ["BASE_LANGUAGE"], "back": ["TARGET_LANGUAGE"], "verificationMethod": "none", "ttsFrontColumn": "BASE_LANGUAGE", "ttsBackColumn": "TARGET_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": false},
-  {"name": "Pronunciation Practice", "front": ["TARGET_LANGUAGE", "PRONUNCIATION"], "back": ["BASE_LANGUAGE"], "verificationMethod": "none", "ttsFrontColumn": "TARGET_LANGUAGE", "ttsBackColumn": "BASE_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": false},
-  {"name": "Translation Practice", "verificationMethod": "multipleChoice", "front": ["BASE_LANGUAGE"], "back": ["TARGET_LANGUAGE"], "validationColumn": "TARGET_LANGUAGE", "ttsFrontColumn": "BASE_LANGUAGE", "ttsBackColumn": "TARGET_LANGUAGE", "alternateUppercase": false, "ttsOnHotkeyOnly": false}
+  {
+    "name": "Reading & Listening",
+    "verificationMethod": "none",
+    "front": [ "TARGET_LANGUAGE" ],
+    "back": [ "TARGET_LANGUAGE", "BASE_LANGUAGE", "PRONUNCIATION", "GRAMMATICAL_TYPE" ],
+    "validationColumn": "none",
+    "ttsFrontColumn": "TARGET_LANGUAGE",
+    "ttsBackColumn": "BASE_LANGUAGE",
+    "alternateUppercase": true,
+    "ttsOnHotkeyOnly": false
+  },
+  {
+    "name": "Reading Comprehension",
+    "verificationMethod": "none",
+    "front": [ "TARGET_LANGUAGE" ],
+    "back": [ "TARGET_LANGUAGE", "BASE_LANGUAGE", "PRONUNCIATION", "EXAMPLE_SENTENCE" ],
+    "validationColumn": "none",
+    "ttsFrontColumn": "none",
+    "ttsBackColumn": "EXAMPLE_SENTENCE",
+    "alternateUppercase": false,
+    "ttsOnHotkeyOnly": false
+  },
+  {
+    "name": "Listening Comprehension",
+    "verificationMethod": "none",
+    "front": [],
+    "back": [ "TARGET_LANGUAGE", "BASE_LANGUAGE", "PRONUNCIATION", "COMMON_COLLOCATION" ],
+    "validationColumn": "none",
+    "ttsFrontColumn": "TARGET_LANGUAGE",
+    "ttsBackColumn": "COMMON_COLLOCATION",
+    "alternateUppercase": false,
+    "ttsOnHotkeyOnly": false
+  },
+  {
+    "name": "Translation Practice",
+    "verificationMethod": "multipleChoice",
+    "front": [ "BASE_LANGUAGE" ],
+    "back": [ "TARGET_LANGUAGE" ],
+    "validationColumn": "TARGET_LANGUAGE",
+    "ttsFrontColumn": "BASE_LANGUAGE",
+    "ttsBackColumn": "TARGET_LANGUAGE",
+    "alternateUppercase": false,
+    "ttsOnHotkeyOnly": false
+  },
+  {
+    "name": "Validated Writing Practice",
+    "verificationMethod": "text",
+    "front": [ "BASE_LANGUAGE" ],
+    "back": [ "TARGET_LANGUAGE", "RELATED_WORD", "RELATION_TYPE", "GRAMMATICAL_TYPE" ],
+    "validationColumn": "TARGET_LANGUAGE",
+    "ttsFrontColumn": "BASE_LANGUAGE",
+    "ttsBackColumn": "TARGET_LANGUAGE",
+    "alternateUppercase": false,
+    "ttsOnHotkeyOnly": false
+  }
 ]


### PR DESCRIPTION
This commit introduces two main changes:

1.  The default skills in `lib/default-skills.json` have been updated to provide better defaults for new users. The order has also been adjusted to be more logical.

2.  Drag-and-drop functionality has been added to the skills list in the settings modal. This allows users to easily reorder their skills. This was implemented using the SortableJS library.