### PR TITLE
Fix: Ensure speaker icon persists on front of card

### DIFF
--- a/app.js
+++ b/app.js
@@ -2776,12 +2776,21 @@ document.addEventListener('DOMContentLoaded', () => {
         const isFlipped = card.classList.contains('flipped');
         const displayer = isFlipped ? ttsLangDisplayBack : ttsLangDisplayFront;
         if (displayer) {
-        // Clear both displays immediately when speaking starts
-            if(ttsLangDisplayFront) ttsLangDisplayFront.textContent = '';
-            if(ttsLangDisplayBack) ttsLangDisplayBack.textContent = '';
+            // When speaking for the back, don't clear the front.
+            // When speaking for the front, clear the back.
+            if (isFlipped) {
+                if (ttsLangDisplayBack) ttsLangDisplayBack.textContent = '';
+            } else {
+                if (ttsLangDisplayFront) ttsLangDisplayFront.textContent = '';
+                if (ttsLangDisplayBack) ttsLangDisplayBack.textContent = '';
+            }
 
             const updateLanguageDisplay = () => {
-                displayer.textContent = finalLang;
+                if (displayer === ttsLangDisplayFront) {
+                    displayer.textContent = `🔊 ${finalLang}`;
+                } else {
+                    displayer.textContent = finalLang;
+                }
             };
 
             // If we are showing the back, delay the update to sync with the animation

--- a/app.js
+++ b/app.js
@@ -1586,9 +1586,17 @@ document.addEventListener('DOMContentLoaded', () => {
             const backRoles = skillConfig.back || [];
             textForFrontDisplay = getTextForRoles(frontRoles, currentRandomBaseIndex);
             textForBackDisplay = getTextForRoles(backRoles, currentRandomBaseIndex);
-            cardFrontContent.innerHTML = `<span>${textForFrontDisplay.replace(/\n/g, '<br>')}</span>`;
+
+            const isAudioOnly = skillConfig && skillConfig.front.length === 0 && skillConfig.ttsFrontColumn && skillConfig.ttsFrontColumn !== 'none';
+
+            if (isAudioOnly) {
+                cardFrontContent.innerHTML = '<span class="speech-icon">🔊</span>';
+            } else {
+                cardFrontContent.innerHTML = `<span>${textForFrontDisplay.replace(/\n/g, '<br>')}</span>`;
+                adjustFontSize(cardFrontContent.querySelector('span'), true);
+            }
+
             cardBackContent.innerHTML = `<span>${textForBackDisplay.replace(/\n/g, '<br>')}</span>`;
-            adjustFontSize(cardFrontContent.querySelector('span'), true);
             adjustFontSize(cardBackContent.querySelector('span'), false);
         }
 

--- a/app.js
+++ b/app.js
@@ -1548,6 +1548,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return skillConfig;
     }
 
+    function isAudioOnly(skillConfig) {
+        return skillConfig && skillConfig.front.length === 0 && skillConfig.ttsFrontColumn && skillConfig.ttsFrontColumn !== 'none';
+    }
+
     /**
      * Flips the current card and handles the flip animation.
      * Also triggers TTS for the revealed side if enabled.
@@ -1587,9 +1591,7 @@ document.addEventListener('DOMContentLoaded', () => {
             textForFrontDisplay = getTextForRoles(frontRoles, currentRandomBaseIndex);
             textForBackDisplay = getTextForRoles(backRoles, currentRandomBaseIndex);
 
-            const isAudioOnly = skillConfig && skillConfig.front.length === 0 && skillConfig.ttsFrontColumn && skillConfig.ttsFrontColumn !== 'none';
-
-            if (isAudioOnly) {
+            if (isAudioOnly(skillConfig)) {
                 cardFrontContent.innerHTML = '<span class="speech-icon">🔊</span>';
             } else {
                 cardFrontContent.innerHTML = `<span>${textForFrontDisplay.replace(/\n/g, '<br>')}</span>`;
@@ -1904,16 +1906,14 @@ document.addEventListener('DOMContentLoaded', () => {
             useUppercase = !useUppercase;
         }
 
-        const isAudioOnly = skillConfig && skillConfig.front.length === 0 && skillConfig.ttsFrontColumn && skillConfig.ttsFrontColumn !== 'none';
-
-        cardFrontContent.innerHTML = isAudioOnly ? '<span class="speech-icon">🔊</span>' : `<span>${displayText.replace(/\n/g, '<br>')}</span>`;
+        cardFrontContent.innerHTML = isAudioOnly(skillConfig) ? '<span class="speech-icon">🔊</span>' : `<span>${displayText.replace(/\n/g, '<br>')}</span>`;
         cardBackContent.innerHTML = `<span>${textForBackDisplay.replace(/\n/g, '<br>')}</span>`;
 
         cardFront.style.fontSize = '';
         cardBackContent.style.fontSize = '';
 
         setTimeout(() => {
-            if (!isAudioOnly) adjustFontSize(cardFrontContent.querySelector('span'), true);
+            if (!isAudioOnly(skillConfig)) adjustFontSize(cardFrontContent.querySelector('span'), true);
             adjustFontSize(cardBackContent.querySelector('span'), false);
         }, 50);
 


### PR DESCRIPTION
The speaker icon, which indicates the language for text-to-speech, was disappearing from the front of the card after a flip cycle (front -> back -> front).

This was because the `speak` function, when called for the back of the card, would clear the text content of both the front and back language displays.

The fix modifies the `speak` function's display logic:
- When speech is initiated for the back of the card, only the back display is cleared, leaving the front display's content intact.
- A speaker emoji (🔊) is now prepended to the language code on the front display to make the icon more explicit.